### PR TITLE
test getting mending with enchant + fixed paper version

### DIFF
--- a/mending-enchant-core/build.gradle.kts
+++ b/mending-enchant-core/build.gradle.kts
@@ -12,6 +12,7 @@ repositories {
     gradlePluginPortal()
     maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
     maven("https://maven.enginehub.org/repo/")
+    maven("https://repo.papermc.io/repository/maven-public/") // MockBukkit
 }
 
 java {
@@ -34,7 +35,13 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.9.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation("com.github.seeseemelk:MockBukkit-v1.20:3.68.0")
+    testImplementation("com.github.seeseemelk:MockBukkit-v1.20:3.70.0")
+}
+
+configurations.all {
+    resolutionStrategy {
+        force("io.papermc.paper:paper-api:1.20.4-R0.1-20240205.114523-90")
+    }
 }
 
 tasks.named<Test>("test") {

--- a/mending-enchant-core/src/test/java/me/crylonz/mendingenchant/MendingEnchantTest.java
+++ b/mending-enchant-core/src/test/java/me/crylonz/mendingenchant/MendingEnchantTest.java
@@ -58,26 +58,50 @@ public class MendingEnchantTest {
         Assertions.assertTrue(esm.hasStoredEnchant(Enchantment.MENDING));
     }
 
-     @Test
-     @DisplayName("Enchanting should give the mending enchant to the tool")
-     public void enchantingForMending(){
-         Player player = server.addPlayer();
-         PermissionAttachment pa = player.addAttachment(plugin);
-         pa.setPermission("mendingenchant.use", true);
+    @Test
+    @DisplayName("Enchanting should give the mending enchant to the tool")
+    public void enchantingForMending(){
+     Player player = server.addPlayer();
+     PermissionAttachment pa = player.addAttachment(plugin);
+     pa.setPermission("mendingenchant.use", true);
 
-         Map<Enchantment, Integer> enchants = new HashMap<>(); // Can't be null
+     Map<Enchantment, Integer> enchants = new HashMap<>(); // Can't be null
 
-         InventoryView view = null;     // Not what is tested here - so set to null
-         Block table = null;            // Not what is tested here - so set to null
-         ItemStack is = null;           // Not what is tested here - so set to null
-         int level = 100;               // Not what is tested here - so set to 10
-         Enchantment hint = null;       // Not what is tested here - so set to null
-         int levelHint = 10;            // Not what is tested here - so set to 10
-         int i = 1;                     // Not what is tested here - so set to 1
+     InventoryView view = null;     // Not what is tested here - so set to null
+     Block table = null;            // Not what is tested here - so set to null
+     ItemStack is = null;           // Not what is tested here - so set to null
+     int level = 100;               // Not what is tested here - so set to 10
+     Enchantment hint = null;       // Not what is tested here - so set to null
+     int levelHint = 10;            // Not what is tested here - so set to 10
+     int i = 1;                     // Not what is tested here - so set to 1
 
-         EnchantItemEvent e = new EnchantItemEvent(player, view, table, is, level, enchants, hint, levelHint, i);
-         server.getPluginManager().callEvent(e);
+     EnchantItemEvent e = new EnchantItemEvent(player, view, table, is, level, enchants, hint, levelHint, i);
+     server.getPluginManager().callEvent(e);
 
-         Assertions.assertNotNull(e.getEnchantsToAdd().get(Enchantment.MENDING));
-     }
+     Assertions.assertNotNull(e.getEnchantsToAdd().get(Enchantment.MENDING));
+    }
+
+    @Test
+    @DisplayName("Mending should not be in the enchant list if there is already Infinity")
+    public void noMendingIfInfinity() {
+        Player player = server.addPlayer();
+        PermissionAttachment pa = player.addAttachment(plugin);
+        pa.setPermission("mendingenchant.use", true);
+
+        Map<Enchantment, Integer> enchants = new HashMap<>();
+        enchants.put(Enchantment.ARROW_INFINITE, 1);
+
+        InventoryView view = null;     // Not what is tested here - so set to null
+        Block table = null;            // Not what is tested here - so set to null
+        ItemStack is = null;           // Not what is tested here - so set to null
+        int level = 100;               // Not what is tested here - so set to 10
+        Enchantment hint = null;       // Not what is tested here - so set to null
+        int levelHint = 10;            // Not what is tested here - so set to 10
+        int i = 1;                     // Not what is tested here - so set to 1
+
+        EnchantItemEvent e = new EnchantItemEvent(player, view, table, is, level, enchants, hint, levelHint, i);
+        server.getPluginManager().callEvent(e);
+
+        Assertions.assertNull(e.getEnchantsToAdd().get(Enchantment.MENDING));
+    }
 }

--- a/mending-enchant-core/src/test/java/me/crylonz/mendingenchant/MendingEnchantTest.java
+++ b/mending-enchant-core/src/test/java/me/crylonz/mendingenchant/MendingEnchantTest.java
@@ -13,6 +13,7 @@ import org.bukkit.event.enchantment.EnchantItemEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
+import org.bukkit.permissions.PermissionAttachment;
 import org.junit.jupiter.api.*;
 
 import java.util.UUID;
@@ -61,17 +62,22 @@ public class MendingEnchantTest {
      @DisplayName("Enchanting should give the mending enchant to the tool")
      public void enchantingForMending(){
          Player player = server.addPlayer();
-         InventoryView view = null;    // Not what is tested here - so set to null
-         Block enchantTable = null;    // Not what is tested here - so set to null
-         ItemStack is = null;          // Not what is tested here - so set to null
-         int level = 10;               // Not what is tested here - so set to 10
-         Map<Enchantment, Integer> enchants = new HashMap<Enchantment, Integer>();
-         Enchantment hint = null;      // Not what is tested here - so set to null
-         int levelHint = 10;           // Not what is tested here - so set to 10
-         int i = 1;                    // Not what is tested here - so set to 1
+         PermissionAttachment pa = player.addAttachment(plugin);
+         pa.setPermission("mendingenchant.use", true);
 
-         server.getPluginManager().callEvent(new EnchantItemEvent(player, view, enchantTable, is, level, enchants, hint, levelHint, i));
+         Map<Enchantment, Integer> enchants = new HashMap<>(); // Can't be null
 
-         Assertions.assertNotNull(enchants.get(Enchantment.MENDING));
+         InventoryView view = null;     // Not what is tested here - so set to null
+         Block table = null;            // Not what is tested here - so set to null
+         ItemStack is = null;           // Not what is tested here - so set to null
+         int level = 100;               // Not what is tested here - so set to 10
+         Enchantment hint = null;       // Not what is tested here - so set to null
+         int levelHint = 10;            // Not what is tested here - so set to 10
+         int i = 1;                     // Not what is tested here - so set to 1
+
+         EnchantItemEvent e = new EnchantItemEvent(player, view, table, is, level, enchants, hint, levelHint, i);
+         server.getPluginManager().callEvent(e);
+
+         Assertions.assertNotNull(e.getEnchantsToAdd().get(Enchantment.MENDING));
      }
 }

--- a/mending-enchant-core/src/test/java/me/crylonz/mendingenchant/MendingEnchantTest.java
+++ b/mending-enchant-core/src/test/java/me/crylonz/mendingenchant/MendingEnchantTest.java
@@ -4,15 +4,20 @@ import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.entity.FishHookMock;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.FishHook;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerFishEvent;
+import org.bukkit.event.enchantment.EnchantItemEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.junit.jupiter.api.*;
 
 import java.util.UUID;
+import java.util.Map;
+import java.util.HashMap;
 
 public class MendingEnchantTest {
     private static ServerMock server;
@@ -51,4 +56,22 @@ public class MendingEnchantTest {
         EnchantmentStorageMeta esm = (EnchantmentStorageMeta) item.getItemMeta();
         Assertions.assertTrue(esm.hasStoredEnchant(Enchantment.MENDING));
     }
+
+     @Test
+     @DisplayName("Enchanting should give the mending enchant to the tool")
+     public void enchantingForMending(){
+         Player player = server.addPlayer();
+         InventoryView view = null;    // Not what is tested here - so set to null
+         Block enchantTable = null;    // Not what is tested here - so set to null
+         ItemStack is = null;          // Not what is tested here - so set to null
+         int level = 10;               // Not what is tested here - so set to 10
+         Map<Enchantment, Integer> enchants = new HashMap<Enchantment, Integer>();
+         Enchantment hint = null;      // Not what is tested here - so set to null
+         int levelHint = 10;           // Not what is tested here - so set to 10
+         int i = 1;                    // Not what is tested here - so set to 1
+
+         server.getPluginManager().callEvent(new EnchantItemEvent(player, view, enchantTable, is, level, enchants, hint, levelHint, i));
+
+         Assertions.assertNotNull(enchants.get(Enchantment.MENDING));
+     }
 }

--- a/mending-enchant-core/src/test/resources/config.yml
+++ b/mending-enchant-core/src/test/resources/config.yml
@@ -8,8 +8,8 @@
 #
 # YOU NEED TO RELOAD/RESTART AFTER ANY CHANGE
 auto-update: false
-DefaultProbability: 6.0
-CustomProbability1: 12.0
-CustomProbability2: 18.0
-CustomProbability3: 24.0
+DefaultProbability: 30.0
+CustomProbability1: 30.0
+CustomProbability2: 30.0
+CustomProbability3: 30.0
 FishingProbability: 100.0


### PR DESCRIPTION
### Tested mending through enchant

1. Added a test that fires an EnchantItemEvent on a player that's permissioned and checked Mending was received
2. Added a test that fires an EnchantItemEvent with the Infinity enchant selected to make sure Mending won't be added


### Fixed paper version

Paper version updates sometimes break mockBukkit. Fixed which version of paper is used to counteract this issue